### PR TITLE
[fix](ONDP-345) Fixed isActive function not detecting page activity correctly

### DIFF
--- a/server-plugin/server-plugin-report-markdown/src/main/java/io/onedev/server/plugin/report/markdown/MarkdownReportTab.java
+++ b/server-plugin/server-plugin-report-markdown/src/main/java/io/onedev/server/plugin/report/markdown/MarkdownReportTab.java
@@ -53,7 +53,7 @@ public class MarkdownReportTab extends BuildTab {
 
 	@Override
 	public boolean isActive(Page currentPage) {
-		if (!super.isActive(currentPage)) {
+		if (super.isActive(currentPage)) {
 			MarkdownReportPage markdownReportPage = (MarkdownReportPage) currentPage;
 			return getTitle().equals(markdownReportPage.getReportName());
 		} else {


### PR DESCRIPTION
This was a bug that was caused by the if statement that calls super.isActive having an incorrect conditional. I changed it and it seems to work better now.

Process:
- Verified all personal review checklist, all pass. Report is available under issue ONDP-345 comments.
- This was tied to issue ONDP-345, I have marked it as being under review